### PR TITLE
Setup options

### DIFF
--- a/lib/music-player.service.ts
+++ b/lib/music-player.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, EventEmitter } from '@angular/core';
+import { Inject, Injectable, EventEmitter, Optional } from '@angular/core';
 import { MusicPlayerEventConstants } from './music-player-events.constants';
 import { ITrackEvent } from './itrack-event.interface';
 import { MusicPlayerUtils } from './music-player.utils';
@@ -30,18 +30,22 @@ export class MusicPlayerService {
 
   private _soundObject: any;
 
-  constructor() {
-    this.init();
+  constructor(
+    @Inject('setupOptions') @Optional() public setupOptions?: Object,
+  ) {
+    this.init(setupOptions);
   }
 
   /**
    * Initialize soundmanager,
    * requires soundmanager2 to be loaded first
    */
-  init(): void {
+  init(setupOptions?: Object): void {
     if(typeof soundManager === 'undefined') {
       alert('Please include SoundManager2 Library!');
     }
+    Object.assign(soundManager.setupOptions, setupOptions);
+    soundManager.setupOptions.ignoreMobileRestrictions = true;
     this._soundObject = soundManager.setup({
       preferFlash: false, // prefer 100% HTML5 mode, where both supported
       debugMode: false,   // enable debugging output

--- a/lib/ngx-soundmanager2.module.ts
+++ b/lib/ngx-soundmanager2.module.ts
@@ -67,11 +67,12 @@ import { MusicPlayerService } from './music-player.service';
 })
 export class NgxSoundmanager2Module {
   constructor() {}
-  static forRoot(): ModuleWithProviders {
+  static forRoot(setupOptions?: Object): ModuleWithProviders {
     return {
       ngModule: NgxSoundmanager2Module,
       providers: [
-        MusicPlayerService
+        MusicPlayerService,
+        { provide: 'setupOptions', useValue: setupOptions }
       ]
     };
   }


### PR DESCRIPTION
# Bug
## Repro steps
1. Run Chrome browser
1. Open developer tools(f12) and toggle device toolbar (ctrl+shift+m)
1. Set view size as Pixel2 or other mobile view size
1. Open demo of ngx-soundmanager2
1. Play any music
1. Add another music to playlist

## Actual
Music stopped. See https://github.com/scottschiller/SoundManager2/issues/144

## Workaround
Set soundManager.setupOptions.ignoreMobileRestrictions to true .

# Desc
There's no way to set setupOptions in ngx-soundmanager. It is still possible to set such options in application modulfe file since soundManager is a global variable. But setting it through ngx sm2 module would be more robust and bug free.
Fix is adding optional parameter of setupOptions which sets soundManager.setupOptions before calling soundManager.setup()
